### PR TITLE
feat: sonner 및 toast 추가

### DIFF
--- a/app/Main/InformationSection/BusSearch/StationSelector/useUserLocation.ts
+++ b/app/Main/InformationSection/BusSearch/StationSelector/useUserLocation.ts
@@ -1,6 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import type { LatLng } from '@/types';
+import { toast } from 'sonner';
 import { SEOUL_LOCATION_INFO } from './constants';
 
 /**
@@ -27,7 +28,7 @@ const useUserLocation = () => {
 
   useEffect(() => {
     if (!('geolocation' in navigator)) {
-      console.warn('위치 정보를 사용할 수 없습니다.');
+      toast.warning('위치 정보를 사용할 수 없어요 😭');
       return;
     }
 
@@ -42,13 +43,13 @@ const useUserLocation = () => {
     const onError = (error: GeolocationPositionError) => {
       switch (error.code) {
         case GeolocationPositionError.PERMISSION_DENIED:
-          window.alert('위치 권한이 필요합니다.');
+          toast.error('위치 권한이 필요해요 🧐');
           break;
         case GeolocationPositionError.POSITION_UNAVAILABLE:
-          window.alert('위치 정보 확인을 실패했습니다.');
+          toast.error('위치 확인을 실패했어요 🥲');
           break;
         case GeolocationPositionError.TIMEOUT:
-          window.alert('위치 정보 요청 시간이 오버됐습니다.');
+          toast.error('위치 요청 시간이 오버됐어요 😇');
           break;
         default:
         // nothing to do.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from 'next';
 import { Inter } from 'next/font/google';
 import Script from 'next/script';
 import { Analytics } from '@vercel/analytics/react';
+import { Toaster } from '@/components/ui/sonner';
 import './globals.css';
 
 export default function RootLayout({
@@ -13,6 +14,7 @@ export default function RootLayout({
     <html lang="ko">
       <body className={inter.className}>
         {children}
+        <Toaster className="pointer-events-auto" />
         <Analytics />
       </body>
       <Script id="load-service-worker">

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -1,0 +1,30 @@
+'use client';
+import { useTheme } from 'next-themes';
+import { Toaster as Sonner } from 'sonner';
+
+type ToasterProps = React.ComponentProps<typeof Sonner>;
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = 'system' } = useTheme();
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps['theme']}
+      className="toaster group"
+      toastOptions={{
+        classNames: {
+          toast:
+            'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
+          description: 'group-[.toast]:text-muted-foreground',
+          actionButton:
+            'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
+          cancelButton:
+            'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',
+        },
+      }}
+      {...props}
+    />
+  );
+};
+
+export { Toaster };

--- a/package.json
+++ b/package.json
@@ -24,9 +24,11 @@
     "framer-motion": "^11.2.11",
     "lucide-react": "^0.376.0",
     "next": "14.2.3",
+    "next-themes": "^0.3.0",
     "react": "^18",
     "react-dom": "^18",
     "react-resizable-panels": "^2.0.19",
+    "sonner": "^1.5.0",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.1"


### PR DESCRIPTION
sonner 패키지를 설치하고 sonner의 toast를 사용할 수 있는 환경을 구성한다.
radix-ui 기반인 shadcn/ui의 sonner를 사용하면 pointer-event: none이 적용되어서
토스트가 자동으로 사라지지 않고, 마우스 오버에도 반응이 없는 문제가 있다.
sonner toast를 사용하기 위한 Toaster에 pointer-event: auto를 적용해서 해결한다.
이번 작업에서는 toast를 사용하기 위한 기본 작업들을 진행하고
현위치를 조회할 때 에러 처리를 toast로 표시하게 만드는 정도만 진행한다.