### PR TITLE
feat: 사용자 현재 위치 갱신 버튼 추가 및 정류소 조회 중심에 점표시 추가

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,9 @@
     "plugin:prettier/recommended",
     "prettier"
   ],
-  "rules": {},
+  "rules": {
+    "no-use-before-define": "off"
+  },
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": "latest",

--- a/app/Main/InformationSection/BusSearch/StationSelector/MapControlBox.tsx
+++ b/app/Main/InformationSection/BusSearch/StationSelector/MapControlBox.tsx
@@ -1,0 +1,28 @@
+import RefreshUserLocationButton from './RefreshUserLocationButton';
+import ReSearchButton from './ReSearchButton';
+
+interface MapControlBoxProps {
+  onRefreshUserLocation: () => void;
+  onReSearchStations: () => void;
+}
+
+/**
+ * 맵 컨트롤 박스 컴포넌트
+ * 맵에서 사용할 여러가지 컨트롤들을 가지고 있는 투명한 박스다.
+ * 컨트롤들은 맵의 우하단에 표시한다.
+ * @param onRefreshUserLocation - 사용자 위치 갱신 이벤트 핸들러
+ * @param onReSearchStations - 정류소 재검색 이벤트 핸들러
+ */
+const MapControlBox = ({
+  onRefreshUserLocation,
+  onReSearchStations,
+}: MapControlBoxProps) => {
+  return (
+    <div className="absolute bottom-0 right-0 z-10 flex flex-col gap-1 bg-transparent p-2">
+      <RefreshUserLocationButton onClick={onRefreshUserLocation} />
+      <ReSearchButton onClick={onReSearchStations} />
+    </div>
+  );
+};
+
+export default MapControlBox;

--- a/app/Main/InformationSection/BusSearch/StationSelector/ReSearchButton.tsx
+++ b/app/Main/InformationSection/BusSearch/StationSelector/ReSearchButton.tsx
@@ -1,4 +1,4 @@
-import { Search as SearchIcon } from 'lucide-react';
+import { RotateCw as ReSearchIcon } from 'lucide-react';
 import {
   TooltipProvider,
   Tooltip,
@@ -31,7 +31,7 @@ const ReSearchButton = ({ className, onClick }: ReSearchButtonProps) => {
             className={cn('rounded-full', className)}
             onClick={onClick}
           >
-            <SearchIcon size={16} />
+            <ReSearchIcon size={16} />
           </Button>
         </TooltipTrigger>
         <TooltipContent className="text-sm text-muted-foreground">

--- a/app/Main/InformationSection/BusSearch/StationSelector/RefreshUserLocationButton.tsx
+++ b/app/Main/InformationSection/BusSearch/StationSelector/RefreshUserLocationButton.tsx
@@ -1,4 +1,4 @@
-import { Search as SearchIcon } from 'lucide-react';
+import { Locate as UserLocationIcon } from 'lucide-react';
 import {
   TooltipProvider,
   Tooltip,
@@ -8,19 +8,20 @@ import {
 import { Button } from '@/components/ui/button';
 import { cn, type ClassValue } from '@/lib/utils';
 
-interface ReSearchButtonProps {
+interface RefreshUserLocationButtonProps {
   className?: ClassValue;
   onClick: () => void;
 }
 
 /**
- * 재검색 버튼 컴포넌트
- * 현재 위치에서 다시 재검색을 실행하는 버튼을 표시한다.
- * 정류장 재검색에대한 툴팁도 같이 표시한다.
+ * 사용자 위치 갱신 버튼 컴포넌트
  * @param className - class name
  * @param onClick - 버튼 클릭 이벤트 핸들러
  */
-const ReSearchButton = ({ className, onClick }: ReSearchButtonProps) => {
+const RefreshUseLocationButton = ({
+  className,
+  onClick,
+}: RefreshUserLocationButtonProps) => {
   return (
     <TooltipProvider>
       <Tooltip>
@@ -31,15 +32,15 @@ const ReSearchButton = ({ className, onClick }: ReSearchButtonProps) => {
             className={cn('rounded-full', className)}
             onClick={onClick}
           >
-            <SearchIcon size={16} />
+            <UserLocationIcon size={16} />
           </Button>
         </TooltipTrigger>
         <TooltipContent className="text-sm text-muted-foreground">
-          이 위치에서 정류장을 다시 검색하기 🔍
+          지금 위치로 지도를 이동할게요 🏃
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>
   );
 };
 
-export default ReSearchButton;
+export default RefreshUseLocationButton;

--- a/app/Main/InformationSection/BusSearch/StationSelector/StationSelector.tsx
+++ b/app/Main/InformationSection/BusSearch/StationSelector/StationSelector.tsx
@@ -19,7 +19,7 @@ interface StationSelectorProps {
  */
 const StationSelector = ({ className, onSelect }: StationSelectorProps) => {
   const [currentLocation, setCurrentLocation] = useState<LatLng | null>(null);
-  const userLocation = useUserLocation();
+  const [userLocation, refreshUserLocation] = useUserLocation();
   useLayoutEffect(() => {
     setCurrentLocation(userLocation);
   }, [userLocation]);
@@ -28,6 +28,11 @@ const StationSelector = ({ className, onSelect }: StationSelectorProps) => {
   const onStationSelect = useCallback(
     (stationId: string) => onSelect(stationId),
     [onSelect],
+  );
+
+  const onRefreshUserLocation = useCallback(
+    () => refreshUserLocation(),
+    [refreshUserLocation],
   );
 
   const onReSearchStations = useCallback((newLocation: LatLng) => {
@@ -40,6 +45,7 @@ const StationSelector = ({ className, onSelect }: StationSelectorProps) => {
         stations={stations}
         currentLocation={currentLocation}
         onStationSelect={onStationSelect}
+        onRefreshUserLocation={onRefreshUserLocation}
         onReSearchStations={onReSearchStations}
       />
     </div>

--- a/app/Main/InformationSection/BusSearch/StationSelector/StationsMap.tsx
+++ b/app/Main/InformationSection/BusSearch/StationSelector/StationsMap.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect } from 'react';
 import { cn } from '@/lib/utils';
 import type { StationInfo } from './types';
 import type { LatLng } from '@/types';
-import ReSearchButton from './ReSearchButton';
+import MapControlBox from './MapControlBox';
 import useKakaoMap from './useKakaoMap';
 import useUpdateMapCenterEffect from './useUpdateMapCenterEffect';
 
@@ -11,6 +11,7 @@ interface StationsMapProps {
   currentLocation: LatLng | null;
   stations: StationInfo[];
   onStationSelect: (stationId: string) => void;
+  onRefreshUserLocation: () => void;
   onReSearchStations: (newLocation: LatLng) => void;
 }
 
@@ -22,6 +23,7 @@ interface StationsMapProps {
  * @param currentLocation - 현재 위치 정보 (위도, 경도)
  * @param stations - 버스 정류장 목록
  * @param onStationSelect - 버스 정류장 선택 이벤트 핸들러
+ * @param onRefreshUserLocation - 유저 위치 갱신 이벤트 핸들러
  * @param onReSearchStations - 버스 정류장 재검색 이벤트 핸들러
  */
 const StationsMap = ({
@@ -29,6 +31,7 @@ const StationsMap = ({
   currentLocation,
   stations,
   onStationSelect,
+  onRefreshUserLocation,
   onReSearchStations,
 }: StationsMapProps) => {
   const [map, mapContainerRef] = useKakaoMap(currentLocation);
@@ -71,7 +74,10 @@ const StationsMap = ({
       ref={mapContainerRef}
       className={cn('relative h-full w-full', className)}
     >
-      <ReSearchButton className="z-10" onClick={onReSearch} />
+      <MapControlBox
+        onRefreshUserLocation={onRefreshUserLocation}
+        onReSearchStations={onReSearch}
+      />
     </div>
   );
 };

--- a/app/Main/InformationSection/BusSearch/StationSelector/StationsMap.tsx
+++ b/app/Main/InformationSection/BusSearch/StationSelector/StationsMap.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { cn } from '@/lib/utils';
 import type { StationInfo } from './types';
 import type { LatLng } from '@/types';
 import MapControlBox from './MapControlBox';
 import useKakaoMap from './useKakaoMap';
 import useUpdateMapCenterEffect from './useUpdateMapCenterEffect';
+import useStationMarkersEffect from './useStationMarkersEffect';
 
 interface StationsMapProps {
   className?: string;
@@ -36,26 +37,7 @@ const StationsMap = ({
 }: StationsMapProps) => {
   const [map, mapContainerRef] = useKakaoMap(currentLocation);
   useUpdateMapCenterEffect(currentLocation, map);
-
-  useEffect(() => {
-    if (!map) {
-      return;
-    }
-
-    stations.forEach((item) => {
-      const marker = new window.kakao.maps.Marker({
-        map: map,
-        position: new window.kakao.maps.LatLng(
-          item.latlng.lat,
-          item.latlng.lng,
-        ),
-        title: item.name,
-      });
-
-      const onMarkerClick = () => onStationSelect(item.id);
-      window.kakao.maps.event.addListener(marker, 'click', onMarkerClick);
-    });
-  }, [stations, map, onStationSelect]);
+  useStationMarkersEffect(map, stations, onStationSelect);
 
   const onReSearch = useCallback(() => {
     if (!map) {

--- a/app/Main/InformationSection/BusSearch/StationSelector/useStationMarkersEffect.ts
+++ b/app/Main/InformationSection/BusSearch/StationSelector/useStationMarkersEffect.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+import type { StationInfo } from './types';
+
+/**
+ * 버스 정류소 마커 표시 이펙트를 사용한다.
+ * 전달 받은 정류소 데이터로 맵에 정류소 마커들을 표시한다.
+ * 마커는 맵의 중심을 기준으로 일정 범위의 정류소만 표시한다.
+ * @param map - 맵 인스턴스
+ * @param stations - 버스 정류장 목록
+ * @param onStationSelect - 버스 정류장 선택 이벤트 핸들러
+ */
+const useStationMarkersEffect = (
+  map: kakao.maps.Map | null,
+  stations: StationInfo[],
+  onStationSelect: (stationId: string) => void,
+) => {
+  const [stationMarkers, setStationMarkers] = useState<kakao.maps.Marker[]>([]);
+  useEffect(() => {
+    if (!map) {
+      return;
+    }
+
+    stationMarkers.forEach((marker) => {
+      marker.setMap(null);
+    });
+
+    const markers = stations.map((item) => {
+      const marker = new window.kakao.maps.Marker({
+        map: map,
+        position: new window.kakao.maps.LatLng(
+          item.latlng.lat,
+          item.latlng.lng,
+        ),
+        title: item.name,
+      });
+
+      const onMarkerClick = () => onStationSelect(item.id);
+      window.kakao.maps.event.addListener(marker, 'click', onMarkerClick);
+
+      return marker;
+    });
+
+    setStationMarkers(markers);
+
+    // stationsMarkers의 변경으로 정류소 마커 설정이 트리거 되지 않게 막아둔다.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stations, map, onStationSelect]);
+};
+
+export default useStationMarkersEffect;

--- a/app/Main/InformationSection/BusSearch/StationSelector/useUpdateMapCenterEffect.ts
+++ b/app/Main/InformationSection/BusSearch/StationSelector/useUpdateMapCenterEffect.ts
@@ -1,8 +1,10 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import type { LatLng } from '@/types';
 
 /**
  * 맵 중앙 위치 업데이트를 사용한다.
+ * 지정한 위치로 맵의 중앙 위치를 이동시키고,
+ * 이 위치에 현위치 마커를 표시한다.
  * @param location - 맵의 중앙으로 업데이트할 위치
  * @param map - Map 인스턴스
  */
@@ -22,6 +24,43 @@ const useUpdateMapCenterEffect = (
     const newCenter = new window.kakao.maps.LatLng(location.lat, location.lng);
     map.panTo(newCenter);
   }, [location]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const [centerMarker, setCenterMarker] = useState<kakao.maps.Marker | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (!map || !location) {
+      centerMarker?.setMap(null);
+      return;
+    }
+
+    if (!centerMarker) {
+      const markerImageSrc = '/images/user-position.svg';
+      const markerImageSize = new window.kakao.maps.Size(16, 16);
+      const markerImageOffset = new window.kakao.maps.Point(8, 8);
+      const markerImage = new window.kakao.maps.MarkerImage(
+        markerImageSrc,
+        markerImageSize,
+        { offset: markerImageOffset },
+      );
+
+      const marker = new window.kakao.maps.Marker({
+        position: new window.kakao.maps.LatLng(location.lat, location.lng),
+        image: markerImage,
+        title: '내 위치',
+      });
+
+      marker.setMap(map);
+      setCenterMarker(marker);
+
+      return;
+    }
+
+    centerMarker.setPosition(
+      new window.kakao.maps.LatLng(location.lat, location.lng),
+    );
+  }, [map, location, centerMarker]);
 };
 
 export default useUpdateMapCenterEffect;

--- a/app/Main/InformationSection/BusSearch/StationSelector/useUserLocation.ts
+++ b/app/Main/InformationSection/BusSearch/StationSelector/useUserLocation.ts
@@ -1,18 +1,24 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type { LatLng } from '@/types';
 import { toast } from 'sonner';
 import { SEOUL_LOCATION_INFO } from './constants';
 
+type UserLocationState = LatLng | null;
+type RefreshUserLocationFunc = () => void;
+type UseUserLocationReturns = [UserLocationState, RefreshUserLocationFunc];
+
 /**
  * 현재 사용자의 위치 정보를 사용한다.
  * 여러가지 위치 정보중 위도와 경도 정보를 사용할 수 있다.
- * @returns 위도와 경도 정보
+ * 사용자 위치를 다시 갱신하는 refresh 함수도 같이 리턴한다.
+ * @returns 위도와 경도 정보 및 사용자 위치 갱신 함수
  * - userLocation.lat: 위도
  * - userLocation.lng: 경도
+ * - refreshUserLocation: 사용자 위치 갱신 함수
  */
-const useUserLocation = () => {
-  const [userLocation, setUserLocation] = useState<LatLng | null>(() => {
+const useUserLocation = (): UseUserLocationReturns => {
+  const [userLocation, setUserLocation] = useState<UserLocationState>(() => {
     if (
       !process.env.NEXT_PUBLIC_TEST_LAT ||
       !process.env.NEXT_PUBLIC_TEST_LNG
@@ -26,7 +32,7 @@ const useUserLocation = () => {
     };
   });
 
-  useEffect(() => {
+  const refreshUserLocation = useCallback<RefreshUserLocationFunc>(() => {
     if (!('geolocation' in navigator)) {
       toast.warning('위치 정보를 사용할 수 없어요 😭');
       return;
@@ -61,7 +67,11 @@ const useUserLocation = () => {
     });
   }, []);
 
-  return userLocation;
+  useEffect(() => {
+    refreshUserLocation();
+  }, [refreshUserLocation]);
+
+  return [userLocation, refreshUserLocation];
 };
 
 export default useUserLocation;

--- a/public/images/user-position.svg
+++ b/public/images/user-position.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="#f31559" stroke="#aa52a2" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle"><circle cx="12" cy="12" r="10"/></svg>


### PR DESCRIPTION
현재 사용자의 위치를 기준으로 맵 위치를 변경하는 버튼과 동작을 추가한다.
그리고 정류소를 조회할 때 조회 기준 지점에 점표시를 추가해서 어디를 기준으로 조회했는지 알려준다.
정류소 재검색 아이콘을 "재"검색에 더 알맞은 아이콘으로 변경한다.
버스 정류소를 재검색하면 정류소 마커가 계속 쌓이는 문제가 있다.
조회시마다 이전에 만든 마커들을 제거하게 설정한다.