### PR TITLE
fix: 과거 버스 도착시간 기준 속성 변경

### DIFF
--- a/app/bus-info/utils.ts
+++ b/app/bus-info/utils.ts
@@ -28,7 +28,7 @@ export const fetchExternalPastBusArrivals = async ({
 export const toPastBusArrivals = (history: ExternalPastBusArrivalsHistory) => {
   const arrivalDates =
     history.response?.msgBody?.pastArrivalList?.map(
-      (item) => item.arrivalDate ?? '',
+      (item) => item.RArrivalDate ?? '',
     ) ?? [];
 
   return arrivalDates.filter((item) => item);


### PR DESCRIPTION
과거 버스 도착시간을 표시할 때 시간의 텀이 긴 버스가 간혹 나온다.
이상해서 확인해보니 외부에서 얻어온 버스 데이터중 일부 시간 데이터에는
속성 값이 없는 경우가 있었다. 그래서 항상 전달되는 속성 값을 사용하게
수정한다.