### PR TITLE
chore: 버스 선택 Drawer 크기를 더 크게 변경

### DIFF
--- a/app/Main/InformationSection/BusSearch/BusSearch.tsx
+++ b/app/Main/InformationSection/BusSearch/BusSearch.tsx
@@ -41,7 +41,7 @@ const BusSearch = ({ buttonClass, onSearch }: BusSearchProps) => {
       <DrawerTrigger asChild>
         <Button className={cn(buttonClass)}>설정</Button>
       </DrawerTrigger>
-      <DrawerContent>
+      <DrawerContent className="h-[98%]">
         <DrawerHeader>
           <DrawerTitle>다른 버스 찾아보기</DrawerTitle>
           <DrawerDescription>
@@ -49,12 +49,12 @@ const BusSearch = ({ buttonClass, onSearch }: BusSearchProps) => {
           </DrawerDescription>
         </DrawerHeader>
         <BusSearchContent
-          className="p-0 sm:mt-4 sm:p-4"
-          stationSeletorClassName="h-52 sm:h-96"
-          busSelectorClassName="px-2 h-60 max-h-60 sm:h-96 sm:max-h-96 sm:px-0"
+          className="flex-auto p-0 sm:mt-4 sm:p-4"
+          stationSeletorClassName="flex-1"
+          busSelectorClassName="px-2 pt-2 flex-1 max-h-[300px] sm:h-96 sm:max-h-96 sm:px-0"
           onBusChange={onBusChange}
         />
-        <DrawerFooter>
+        <DrawerFooter className="py-8">
           <DrawerClose asChild>
             <Button className="sm:mx-auto sm:w-1/3" onClick={onSearchClick}>
               조회

--- a/app/Main/InformationSection/BusSearch/BusSearchContent.tsx
+++ b/app/Main/InformationSection/BusSearch/BusSearchContent.tsx
@@ -45,7 +45,7 @@ const BusSearchContent = ({
   );
 
   return (
-    <div className={cn('flex flex-col gap-8', className)}>
+    <div className={cn('flex flex-col', className)}>
       <StationSelector
         className={stationSeletorClassName}
         onSelect={onStationSelect}


### PR DESCRIPTION
버스를 선택할 때 사용하는 Drawer의 크기는 필요한 높이만큼만 차지한다.
정류장을 선택하기 위한 지도나 버스 목록이 모두 미리 지정한 크기만큼 표시하고
이걸 포함한 크기로 표시한다. 하지만 모바일 화면에서는 지도가 작아 답답해
보인다. 그래서 Drawer의 높이를 디바이스 화면의 98% 까지 늘리고, 지도와
버스 목록이 1:1 비율로 차지하게 스타일을 수정한다.
단, 버스 목록은 최대 높이를 제한한다.
이렇게 설정하면 이전보다 지도 크기가 커져서 나름 더 시원하게 정류장을 탐색할
수 있을 것 같다. 당초 목적은 모바일 화면의 개선이지만 데스크탑도 굳이 다르게
설정할 필요가 없을 것 같다. Drawer 높이 98%를 적용하고 적당히 내부 요소들의
스타일을 조정한다.