### PR TITLE
fix: 모바일 화면에서 조회 버튼이 나오지 않는 문제 수정

### DIFF
--- a/app/Main/InformationSection/BusSearch/StationSelector/StationSelector.tsx
+++ b/app/Main/InformationSection/BusSearch/StationSelector/StationSelector.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useCallback, useLayoutEffect, useState } from 'react';
-import { cn } from '@/lib/utils';
 import type { LatLng } from '@/types';
 import StationsMap from './StationsMap';
 import useUserLocation from './useUserLocation';
@@ -40,7 +39,7 @@ const StationSelector = ({ className, onSelect }: StationSelectorProps) => {
   }, []);
 
   return (
-    <div className={cn('h-96', className)} data-vaul-no-drag>
+    <div className={className} data-vaul-no-drag>
       <StationsMap
         stations={stations}
         currentLocation={currentLocation}


### PR DESCRIPTION
이전 작업으로 버스 선택 Drawer의 크기와 내부 요소 스타일을 조정했었다.
하지만 이 작업이후 내용이 너무 커서 버스 조회 버튼이 화면밖으로 밀리는
문제가 발생한다. 원인은 정류장 탐색에 사용하는 지도 컴포넌트에 설정해둔
높이 값 때문인 것 같다. 상위 요소에서 지도는 가능한 만큼의 높이를 차지하게
설정했지만 내부의 고정 높이 값이 있어서 전체 높이가 잘 조정되지 못한 것
같다. 이 고정 높이 값을 제거해서 가능한 만큼만 높이가 설정되게 만들어
조회 버튼이 다시 보이게 만든다.