### PR TITLE
feat: 버스 선택 UI를 Chip 모양으로 변경

### DIFF
--- a/app/Main/InformationSection/BusSearch/BusSearch.tsx
+++ b/app/Main/InformationSection/BusSearch/BusSearch.tsx
@@ -27,17 +27,18 @@ interface BusSearchProps {
  * @param onSearch - 조회 버튼 클릭 이벤트 핸들러
  */
 const BusSearch = ({ buttonClass, onSearch }: BusSearchProps) => {
-  const [targetBusRoute, setTargetBusRoute] = useState<BusRoute | null>(null);
-  const onBusChange = (newBus: BusRoute) => {
-    setTargetBusRoute(newBus);
+  const [isOpen, setIsOpen] = useState(false);
+  const onOpenChange = (open: boolean) => {
+    setIsOpen(open);
   };
 
-  const onSearchClick = () => {
-    onSearch(targetBusRoute);
+  const onBusSelect = (newBusRoute: BusRoute) => {
+    onSearch(newBusRoute);
+    setIsOpen(false);
   };
 
   return (
-    <Drawer>
+    <Drawer open={isOpen} onOpenChange={onOpenChange}>
       <DrawerTrigger asChild>
         <Button className={cn(buttonClass)}>설정</Button>
       </DrawerTrigger>
@@ -51,14 +52,12 @@ const BusSearch = ({ buttonClass, onSearch }: BusSearchProps) => {
         <BusSearchContent
           className="flex-auto p-0 sm:mt-4 sm:p-4"
           stationSeletorClassName="flex-1"
-          busSelectorClassName="px-2 pt-2 flex-1 max-h-[300px] sm:h-96 sm:max-h-96 sm:px-0"
-          onBusChange={onBusChange}
+          busSelectorClassName="px-2 pt-4 h-[200px] max-h-[200px] sm:h-96 sm:max-h-96 sm:px-0"
+          onBusSelect={onBusSelect}
         />
         <DrawerFooter className="py-8">
           <DrawerClose asChild>
-            <Button className="sm:mx-auto sm:w-1/3" onClick={onSearchClick}>
-              조회
-            </Button>
+            <Button className="sm:mx-auto sm:w-1/5">닫기</Button>
           </DrawerClose>
         </DrawerFooter>
       </DrawerContent>

--- a/app/Main/InformationSection/BusSearch/BusSearchContent.tsx
+++ b/app/Main/InformationSection/BusSearch/BusSearchContent.tsx
@@ -11,7 +11,7 @@ interface BusSearchContentProps {
   className?: string;
   stationSeletorClassName?: string;
   busSelectorClassName?: string;
-  onBusChange: (targetBus: BusRoute) => void;
+  onBusSelect: (targetBusRoute: BusRoute) => void;
 }
 
 /**
@@ -21,28 +21,19 @@ interface BusSearchContentProps {
  * @param className - 컴포넌트에 적용할 class name
  * @param stationSeletorClassName - 버스 정류소 선택 맵에 적용할 class name
  * @param busSelectorClassName - 버스 선택 목록에 적용할 class name
- * @param onBusChange - 버스 변경 이벤트 핸들러
+ * @param onBusSelect - 버스 선택 이벤트 핸들러
  */
 const BusSearchContent = ({
   className,
   stationSeletorClassName,
   busSelectorClassName,
-  onBusChange,
+  onBusSelect,
 }: BusSearchContentProps) => {
   const [busRoutes, setBusRoutes] = useState<BusRoute[]>([]);
   const onStationSelect = useCallback(async (newStationId: string) => {
     const newBusRoutes = await getBusRoutes(newStationId);
     setBusRoutes(newBusRoutes);
   }, []);
-
-  const [currentBusRoute, setCurrentBusRoute] = useState<BusRoute | null>(null);
-  const onTargetBusSelect = useCallback(
-    (newBusRoute: BusRoute) => {
-      setCurrentBusRoute(newBusRoute);
-      onBusChange(newBusRoute);
-    },
-    [onBusChange],
-  );
 
   return (
     <div className={cn('flex flex-col', className)}>
@@ -53,8 +44,7 @@ const BusSearchContent = ({
       <BusSelector
         className={busSelectorClassName}
         busRoutes={busRoutes}
-        currentBusRoute={currentBusRoute}
-        onSelect={onTargetBusSelect}
+        onSelect={onBusSelect}
       />
     </div>
   );

--- a/app/Main/InformationSection/BusSearch/BusSelector/BusSelector.tsx
+++ b/app/Main/InformationSection/BusSearch/BusSelector/BusSelector.tsx
@@ -1,13 +1,11 @@
-import { Check as CheckIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { Table, TableBody, TableCell, TableRow } from '@/components/ui/table';
 import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
+import { BusChip } from '@/components/widget';
 import type { BusRoute } from '@/types';
 
 interface BusSelectorProps {
   className?: string;
   busRoutes: BusRoute[];
-  currentBusRoute: BusRoute | null;
   onSelect: (route: BusRoute) => void;
 }
 
@@ -17,15 +15,9 @@ interface BusSelectorProps {
  * 버스를 선택할 수 있으며, 선택한 버스는 다르게 표시한다.
  * @param className - 컴포넌트에 적용할 class name
  * @param busRoutes - 버스 노선 목록
- * @param currentBusRoute - 현재 선택된 버스 노선
  * @param onSelect - 버스 노선 선택 이벤트 핸들러
  */
-const BusSelector = ({
-  className,
-  busRoutes,
-  currentBusRoute,
-  onSelect,
-}: BusSelectorProps) => {
+const BusSelector = ({ className, busRoutes, onSelect }: BusSelectorProps) => {
   if (busRoutes.length === 0) {
     return (
       <div
@@ -39,27 +31,21 @@ const BusSelector = ({
   }
 
   return (
-    <ScrollArea>
-      <div className={className}>
-        <Table>
-          <TableBody>
-            {busRoutes.map((route: BusRoute) => (
-              <TableRow
-                key={route.routeId}
-                className={`cursor-pointer ${currentBusRoute?.routeId === route.routeId && 'bg-muted/50'}`}
-                onClick={() => onSelect(route)}
-              >
-                <TableCell>{route.routeTypeName}</TableCell>
-                <TableCell>{route.routeName}</TableCell>
-                <TableCell className="w-[50px]">
-                  {currentBusRoute?.routeId === route.routeId && (
-                    <CheckIcon className="stroke-gray-500" />
-                  )}
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+    <ScrollArea data-vaul-no-drag>
+      <div
+        className={cn(
+          'flex flex-row flex-wrap content-start items-center justify-center gap-2',
+          className,
+        )}
+      >
+        {busRoutes.map((route: BusRoute) => (
+          <BusChip
+            key={route.routeId}
+            name={route.routeName}
+            typeIndex={route.routeTypeCd}
+            onClick={() => onSelect(route)}
+          />
+        ))}
       </div>
       <ScrollBar orientation="vertical" />
     </ScrollArea>

--- a/app/Main/InformationSection/BusSearch/StationSelector/StationsMap.tsx
+++ b/app/Main/InformationSection/BusSearch/StationSelector/StationsMap.tsx
@@ -54,7 +54,7 @@ const StationsMap = ({
   return (
     <div
       ref={mapContainerRef}
-      className={cn('relative h-full w-full', className)}
+      className={cn('relative h-full w-full sm:rounded-xl', className)}
     >
       <MapControlBox
         onRefreshUserLocation={onRefreshUserLocation}

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        default:
+          'border-transparent bg-primary text-primary-foreground hover:bg-primary/80',
+        secondary:
+          'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        destructive:
+          'border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80',
+        outline: 'text-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/components/widget/BusBadge/BusBadge.tsx
+++ b/components/widget/BusBadge/BusBadge.tsx
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { getBusColor } from '@/utils/busRoute';
+
+interface BusBadgeProps {
+  name: string;
+  typeIndex: string;
+}
+
+/**
+ * 버스 뱃지 컴포넌트
+ * 버스 타입에 맞는 배경 컬러와 이름을 뱃지 모양으로 표시한다.
+ * @param name - 버스 이름
+ * @param typeIndex - 버스 타입 인덱스
+ */
+const BusBadge = ({ name, typeIndex }: BusBadgeProps) => {
+  const busColor = useMemo(() => getBusColor(typeIndex), [typeIndex]);
+
+  return <Badge style={{ backgroundColor: busColor }}>{name}</Badge>;
+};
+
+export default BusBadge;

--- a/components/widget/BusBadge/index.ts
+++ b/components/widget/BusBadge/index.ts
@@ -1,0 +1,1 @@
+export { default } from './BusBadge';

--- a/components/widget/BusChip/BusChip.tsx
+++ b/components/widget/BusChip/BusChip.tsx
@@ -1,0 +1,33 @@
+import { useMemo } from 'react';
+import { BusBadge } from '@/components/widget';
+import { getBusType } from '@/utils/busRoute';
+
+interface BusChipProps {
+  name: string;
+  typeIndex: string;
+  onClick?: () => void;
+}
+
+/**
+ * 버스 칩 컴포넌트
+ * 버스 뱃지와 버스의 타입을 칩 모양으로 표시한다.
+ * 화면 크기에 따라 칩의 모양을 조금 달라진다.
+ * @param name - 버스 이름
+ * @param typeIndex - 버스 타입 인덱스
+ * @param onClick - 클릭 이벤트 핸들러
+ */
+const BusChip = ({ name, typeIndex, onClick }: BusChipProps) => {
+  const busType = useMemo(() => getBusType(typeIndex), [typeIndex]);
+
+  return (
+    <div
+      className="flex h-fit w-fit cursor-pointer flex-row items-center rounded-full border border-slate-300 p-0.5 transition-colors hover:bg-slate-50 sm:p-1.5"
+      onClick={onClick}
+    >
+      <BusBadge name={name} typeIndex={typeIndex} />
+      <span className="px-2 text-xs text-slate-700 sm:text-sm">{busType}</span>
+    </div>
+  );
+};
+
+export default BusChip;

--- a/components/widget/BusChip/index.ts
+++ b/components/widget/BusChip/index.ts
@@ -1,0 +1,1 @@
+export { default } from './BusChip';

--- a/components/widget/index.ts
+++ b/components/widget/index.ts
@@ -1,0 +1,5 @@
+export { default as BusBadge } from './BusBadge';
+export { default as BusChip } from './BusChip';
+export { default as BusDepartureCard } from './BusDepartureCard';
+export { default as BusName } from './BusName';
+export { default as PastBusTimes } from './PastBusTimes';


### PR DESCRIPTION
정류장의 버스 선택 UI를 변경한다.
이전에는 임시로 테이블 컴포넌트를 사용해서 버스 목록을 표시했다.
하지만 쓸데없이 공간이 남아 어색하게 보이므로 Chip 목록으로 변경한다.
버스를 표시하는 칩은 버스에 맞는 컬러와 이름을 보여주는 뱃지와
버스 타입 텍스트로 구성한다. 이 버스 칩들은 flex-wrap으로 묶어서 보여준다.
칩 목록으로 바꿔보니 굳이 선택후 조회 버튼 클릭을 할 필요는 없는 것 같다.
버스를 선택하면 바로 조회 동작을 처리하게 바꾼다.