### PR TITLE
chore: 버스 선택 목록에 애니메이션 적용

### DIFF
--- a/app/Main/InformationSection/BusSearch/BusSelector/BusSelector.tsx
+++ b/app/Main/InformationSection/BusSearch/BusSelector/BusSelector.tsx
@@ -1,7 +1,13 @@
+import { motion } from 'framer-motion';
 import { cn } from '@/lib/utils';
 import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
 import { BusChip } from '@/components/widget';
 import type { BusRoute } from '@/types';
+import {
+  BUS_CONTAINER_ANIMATION,
+  BUS_ITEM_ANIMATION,
+  BUS_ITEM_HOVER_ANIMATION,
+} from './constants';
 
 interface BusSelectorProps {
   className?: string;
@@ -30,23 +36,34 @@ const BusSelector = ({ className, busRoutes, onSelect }: BusSelectorProps) => {
     );
   }
 
+  const busContainerRenderKey = busRoutes[0].stationId;
+
   return (
     <ScrollArea data-vaul-no-drag>
-      <div
+      <motion.div
         className={cn(
           'flex flex-row flex-wrap content-start items-center justify-center gap-2',
           className,
         )}
+        key={busContainerRenderKey}
+        variants={BUS_CONTAINER_ANIMATION}
+        initial="hidden"
+        animate="appear"
       >
         {busRoutes.map((route: BusRoute) => (
-          <BusChip
+          <motion.div
             key={route.routeId}
-            name={route.routeName}
-            typeIndex={route.routeTypeCd}
-            onClick={() => onSelect(route)}
-          />
+            variants={BUS_ITEM_ANIMATION}
+            whileHover={BUS_ITEM_HOVER_ANIMATION}
+          >
+            <BusChip
+              name={route.routeName}
+              typeIndex={route.routeTypeCd}
+              onClick={() => onSelect(route)}
+            />
+          </motion.div>
         ))}
-      </div>
+      </motion.div>
       <ScrollBar orientation="vertical" />
     </ScrollArea>
   );

--- a/app/Main/InformationSection/BusSearch/BusSelector/constants.ts
+++ b/app/Main/InformationSection/BusSearch/BusSelector/constants.ts
@@ -1,0 +1,33 @@
+type BusListAnimation = Readonly<{
+  hidden: Record<string, unknown>;
+  appear: Record<string, unknown>;
+}>;
+
+/**
+ * 버스 목록 컨테이너 애니메이션
+ * 목록은 특별한 애니메이션을 적용하지는 않고,
+ * 키워드 설정과 자식 아이템 간격을 조정한다.
+ */
+export const BUS_CONTAINER_ANIMATION: BusListAnimation = {
+  hidden: {},
+  appear: {
+    transition: {
+      staggerChildren: 0.04,
+    },
+  },
+};
+
+/**
+ * 버스 목록 아이템 애니메이션
+ */
+export const BUS_ITEM_ANIMATION: BusListAnimation = {
+  hidden: { opacity: 0, y: 20 },
+  appear: { opacity: 1, y: 0 },
+};
+
+/**
+ * 버스 목록 아이템 hover 상태 애니메이션
+ */
+export const BUS_ITEM_HOVER_ANIMATION = {
+  scale: 1.025,
+} as const;


### PR DESCRIPTION
버스를 선택할 때 정류장을 지나는 여러 버스들을 칩 UI로 보여준다.
이 칩 목록을 표시할 때 애니메이션을 적용한다.
각 아이템 별로 딜레이를 주고, opacity와 y 위치가 바뀌는 애니메이션을 적용한다.
애니메이션은 framer-motion에서 제공하는 motion 컴포넌트를 활용한다.
컨테이너는 motion.div 컴포넌트로 변경하고, 버스 칩 아이템들은
motion.div 컴포넌트로 감싸서 framer-motion으로 애니메이션을 적용한다.